### PR TITLE
Enable support for multiple statsd endpoints.

### DIFF
--- a/lib/Etsy/StatsD.pm
+++ b/lib/Etsy/StatsD.pm
@@ -81,13 +81,13 @@ sub new {
     if( ref $host eq 'ARRAY' ) {
         foreach my $addr ( @{ $host } ) {
             my ($addr_host,$addr_port) = split /:/, $addr;
-            $addr_port //= $port;
+            $addr_port ||= $port;
             push @connections, [ $addr_host, $addr_port ];
         }
     }
     else {
         my ($addr_host,$addr_port) = split /:/, $host;
-        $addr_port //= $port;
+        $addr_port ||= $port;
         push @connections, [ $addr_host, $addr_port ];
     }
 
@@ -186,9 +186,10 @@ sub send {
 	#failures in any of this can be silently ignored
 	my $count  = 0;
 	foreach my $socket ( @{ $self->{sockets} } ) {
-        # Using foreach/keys because each iterator is unreliable when nested
-        foreach my $stat ( keys %$sampled_data ) {
-            CORE::send($socket, "$stat:$sampled_data->{$stat}\n", 0);
+        # calling keys() resets the each() iterator
+        keys %$sampled_data;
+        while ( my ( $stat,$value ) = each %$sampled_data ) {
+            CORE::send($socket, "$stat:$value\n", 0);
             ++$count;
         }
     }

--- a/lib/Etsy/StatsD.pm
+++ b/lib/Etsy/StatsD.pm
@@ -109,7 +109,7 @@ sub new {
             $addr_proto = lc $addr_proto;  # Normalize to lowercase
             # Check validity
             if( !exists $protos{$addr_proto} ) {
-                carp sprintf("Invalid protocol  '%s', valid: %s", $addr_proto, join(', ', sort keys %protos));
+                croak sprintf("Invalid protocol  '%s', valid: %s", $addr_proto, join(', ', sort keys %protos));
             }
         }
         else {

--- a/lib/Etsy/StatsD.pm
+++ b/lib/Etsy/StatsD.pm
@@ -10,6 +10,32 @@ our $VERSION = 1.000002;
 
 Etsy::StatsD - Object-Oriented Client for Etsy's StatsD Server
 
+=head1 SYNOPSIS
+
+    use Etsy::StatsD;
+
+    # Increment a counter
+    my $statsd = Etsy::StatsD->new();
+    $statsd->increment( 'app.method.success' );
+
+
+    # Time something
+    use Time::HiRes;
+
+    my $start_time = time;
+    $app->do_stuff;
+    my $done_time = time;
+
+    # Timers are expected in milliseconds
+    $statsd->timing( 'app.method', ($done_time - $start_time) * 1000 );
+
+    # Send to two StatsD Endpoints simultaneously
+    my $repl_statsd = Etsy::StatsD->new(["statsd1","statsd2"]);
+
+    # On two different ports:
+    my $repl_statsd = Etsy::StatsD->new(["statsd1","statsd1:8126"]);
+
+
 =head1 DESCRIPTION
 
 =cut
@@ -20,6 +46,27 @@ Etsy::StatsD - Object-Oriented Client for Etsy's StatsD Server
 
 Create a new instance.
 
+=over
+
+=item HOST
+
+Default is localhost.  It may be in the form of '<host>:<port>', in which case,
+the port specified will be used instead of the PORT argument.  The argument may
+also be an array reference of strings in the form of "<host>" or
+"<host>:<port>".  If the port is not specified, the default port specified by
+the PORT argument will be used.
+
+=item PORT
+
+Default is 8125.  Will be used as the default port for any HOST argument not explicitly defining port.
+
+=item SAMPLE_RATE
+
+Default is undefined, or no sampling performed.  Specify a rate as a decimal between 0 and 1 to enable
+sampling. e.g. 0.5 for 50%.
+
+=back
+
 =cut
 
 sub new {
@@ -27,13 +74,37 @@ sub new {
 	$host = 'localhost' unless defined $host;
 	$port = 8125        unless defined $port;
 
-	my $sock = new IO::Socket::INET(
-		PeerAddr => $host,
-		PeerPort => $port,
-		Proto    => 'udp',
-	) or croak "Failed to initialize socket: $!";
+    # Handle multiple connections and
+    #  allow different ports to be specified
+    #  in the form of "<host>:<port>"
+    my @connections = ();
+    if( ref $host eq 'ARRAY' ) {
+        foreach my $addr ( @{ $host } ) {
+            my ($addr_host,$addr_port) = split /:/, $addr;
+            $addr_port //= $port;
+            push @connections, [ $addr_host, $addr_port ];
+        }
+    }
+    else {
+        my ($addr_host,$addr_port) = split /:/, $host;
+        $addr_port //= $port;
+        push @connections, [ $addr_host, $addr_port ];
+    }
 
-	bless { socket => $sock, sample_rate => $sample_rate }, $class;
+    my @sockets = ();
+    foreach my $conn ( @connections ) {
+        my $sock = new IO::Socket::INET(
+            PeerAddr => $conn->[0],
+            PeerPort => $conn->[1],
+            Proto    => 'udp',
+        ) or carp "Failed to initialize socket: $!";
+
+        push @sockets, $sock if defined $sock;
+    }
+    # Check that we have at least 1 socket to send to
+    croak "Failed to initialize any sockets." unless @sockets;
+
+	bless { sockets => \@sockets, sample_rate => $sample_rate }, $class;
 }
 
 =item timing(STAT, TIME, SAMPLE_RATE)
@@ -114,17 +185,14 @@ sub send {
 
 	#failures in any of this can be silently ignored
 	my $count  = 0;
-	my $socket = $self->{socket};
-	while ( my ( $stat, $value ) = each %$sampled_data ) {
-		_send_to_sock($socket, "$stat:$value\n");
-		++$count;
-	}
+	foreach my $socket ( @{ $self->{sockets} } ) {
+        # Using foreach/keys because each iterator is unreliable when nested
+        foreach my $stat ( keys %$sampled_data ) {
+            CORE::send($socket, "$stat:$sampled_data->{$stat}\n", 0);
+            ++$count;
+        }
+    }
 	return $count;
-}
-
-sub _send_to_sock( $$ ) {
-  my ($sock,$msg) = @_;
-  CORE::send( $sock, $msg, 0 );
 }
 
 =head1 SEE ALSO

--- a/lib/Etsy/StatsD.pm
+++ b/lib/Etsy/StatsD.pm
@@ -36,7 +36,7 @@ Etsy::StatsD - Object-Oriented Client for Etsy's StatsD Server
     my $repl_statsd = Etsy::StatsD->new(["statsd1","statsd1:8126"]);
 
     # Use TCP to a collector (you must specify a port)
-    my $important_stats = Etsy::StatsD->new("bizstats1:8125:tcp");
+    my $important_stats = Etsy::StatsD->new(["bizstats1:8125:tcp"]);
 
 
 =head1 DESCRIPTION
@@ -53,12 +53,13 @@ Create a new instance.
 
 =item HOST
 
-Default is localhost.  It may be in the form of '<host>:<port>' or
-'<host>:<port>:<proto>', The argument may also be an array reference of strings
-in the form of "<host>", "<host>:<port>", or "<host>:<port>:<proto>".  If the
-port is not specified, the default port specified by the PORT argument will be
-used.  If the protocol is not specified, or is not "tcp" or "udp", "udp" will be
-set.  The only way to change the protocol, is to specify the host, port and protocol.
+
+If the argument is a string, it must be a hostname or IP only.  The default is
+'localhost'.  The argument may also be an array reference of strings in the
+form of "<host>", "<host>:<port>", or "<host>:<port>:<proto>".  If the port is
+not specified, the default port specified by the PORT argument will be used.
+If the protocol is not specified, or is not "tcp" or "udp", "udp" will be set.
+The only way to change the protocol, is to specify the host, port and protocol.
 
 =item PORT
 
@@ -80,7 +81,7 @@ sub new {
 
     # Handle multiple connections and
     #  allow different ports to be specified
-    #  in the form of "<host>:<port>"
+    #  in the form of "<host>:<port>:<proto>"
     my %protos = map { $_ => 1 } qw(tcp udp);
     my @connections = ();
     if( ref $host eq 'ARRAY' ) {
@@ -102,20 +103,7 @@ sub new {
         }
     }
     else {
-        my ($addr_host,$addr_port,$addr_proto) = split /:/, $host;
-        $addr_port  ||= $port;
-        # Validate the protocol
-        if( defined $addr_proto ) {
-            $addr_proto = lc $addr_proto;  # Normalize to lowercase
-            # Check validity
-            if( !exists $protos{$addr_proto} ) {
-                croak sprintf("Invalid protocol  '%s', valid: %s", $addr_proto, join(', ', sort keys %protos));
-            }
-        }
-        else {
-            $addr_proto = 'udp';
-        }
-        push @connections, [ $addr_host, $addr_port, $addr_proto ];
+        push @connections, [ $host, $port, 'udp' ];
     }
 
     my @sockets = ();

--- a/lib/Etsy/StatsD.pm
+++ b/lib/Etsy/StatsD.pm
@@ -87,16 +87,34 @@ sub new {
         foreach my $addr ( @{ $host } ) {
             my ($addr_host,$addr_port,$addr_proto) = split /:/, $addr;
             $addr_port  ||= $port;
-            # Default to UDP if we get junk
-            $addr_proto = defined $addr_proto && exists $protos{$addr_proto} ? $addr_proto : 'udp';
+            # Validate the protocol
+            if( defined $addr_proto ) {
+                $addr_proto = lc $addr_proto;  # Normalize to lowercase
+                # Check validity
+                if( !exists $protos{$addr_proto} ) {
+                    croak sprintf("Invalid protocol  '%s', valid: %s", $addr_proto, join(', ', sort keys %protos));
+                }
+            }
+            else {
+                $addr_proto = 'udp';
+            }
             push @connections, [ $addr_host, $addr_port, $addr_proto ];
         }
     }
     else {
         my ($addr_host,$addr_port,$addr_proto) = split /:/, $host;
         $addr_port  ||= $port;
-        # Default to UDP if we get junk
-        $addr_proto = defined $addr_proto && exists $protos{$addr_proto} ? $addr_proto : 'udp';
+        # Validate the protocol
+        if( defined $addr_proto ) {
+            $addr_proto = lc $addr_proto;  # Normalize to lowercase
+            # Check validity
+            if( !exists $protos{$addr_proto} ) {
+                carp sprintf("Invalid protocol  '%s', valid: %s", $addr_proto, join(', ', sort keys %protos));
+            }
+        }
+        else {
+            $addr_proto = 'udp';
+        }
         push @connections, [ $addr_host, $addr_port, $addr_proto ];
     }
 

--- a/t/Etsy-StatsD.t
+++ b/t/Etsy-StatsD.t
@@ -1,5 +1,5 @@
 use strict;
-use Test::More tests=>17;
+use Test::More tests=>20;
 use Test::MockModule;
 use Etsy::StatsD;
 
@@ -17,7 +17,7 @@ my $update = 5;
 my $time = 1234;
 
 ok (my $statsd = Etsy::StatsD->new );
-is ( $statsd->{socket}->peerport, 8125, 'used default port');
+is ( $statsd->{sockets}[0]->peerport, 8125, 'used default port');
 
 $data = {};
 ok( $statsd->timing($bucket,$time) );
@@ -45,4 +45,8 @@ is( $data->{a}, "1|c");
 is( $data->{b}, "1|c");
 
 ok ( my $remote = Etsy::StatsD->new('localhost', 123));
-is ( $remote->{socket}->peerport, 123, 'used specified port');
+is ( $remote->{sockets}[0]->peerport, 123, 'used specified port');
+
+ok ( my $spray = Etsy::StatsD->new(['localhost','localhost:8126'], 8125) );
+is ( $spray->{sockets}[0]->peerport, 8125, 'port works in array of hosts');
+is ( $spray->{sockets}[1]->peerport, 8126, 'custom port works in array of hosts');

--- a/t/Etsy-StatsD.t
+++ b/t/Etsy-StatsD.t
@@ -62,7 +62,7 @@ is ( $spray->{sockets}[2]->protocol, 6, 'TCP protocol  works in array of hosts')
 
 my $err;
 eval {
-    my $t = Etsy::StatsD->new('localhost:8126:igmp');
+    my $t = Etsy::StatsD->new(['localhost:8126:igmp']);
 } or do { $err = $@; };
 ok( defined $err && $err =~ /Invalid protocol/, "invalid protocol dies" ) or diag($err);
 

--- a/t/Etsy-StatsD.t
+++ b/t/Etsy-StatsD.t
@@ -1,6 +1,7 @@
 use strict;
-use Test::More tests=>20;
+use Test::More tests=>22;
 use Test::MockModule;
+use Test::TCP;
 use Etsy::StatsD;
 
 my $module = Test::MockModule->new('Etsy::StatsD');
@@ -47,6 +48,13 @@ is( $data->{b}, "1|c");
 ok ( my $remote = Etsy::StatsD->new('localhost', 123));
 is ( $remote->{sockets}[0]->peerport, 123, 'used specified port');
 
-ok ( my $spray = Etsy::StatsD->new(['localhost','localhost:8126'], 8125) );
+my $mock_server;
+ok( $mock_server = Test::TCP->new(
+        listen => 1,
+        code   => sub {  },
+    )
+);
+ok ( my $spray = Etsy::StatsD->new(['localhost','localhost:8126',sprintf('localhost:%d:tcp', $mock_server->port)], 8125) );
 is ( $spray->{sockets}[0]->peerport, 8125, 'port works in array of hosts');
 is ( $spray->{sockets}[1]->peerport, 8126, 'custom port works in array of hosts');
+is ( $spray->{sockets}[2]->protocol, 6, 'TCP protocol  works in array of hosts');

--- a/t/Etsy-StatsD.t
+++ b/t/Etsy-StatsD.t
@@ -1,5 +1,5 @@
 use strict;
-use Test::More tests=>22;
+use Test::More tests=>23;
 use Test::MockModule;
 use Test::TCP;
 use Etsy::StatsD;
@@ -17,7 +17,7 @@ my $bucket = 'test';
 my $update = 5;
 my $time = 1234;
 
-ok (my $statsd = Etsy::StatsD->new );
+ok (my $statsd = Etsy::StatsD->new, "create an object" );
 is ( $statsd->{sockets}[0]->peerport, 8125, 'used default port');
 
 $data = {};
@@ -45,16 +45,23 @@ ok( $statsd->update(['a','b']) );
 is( $data->{a}, "1|c");
 is( $data->{b}, "1|c");
 
-ok ( my $remote = Etsy::StatsD->new('localhost', 123));
+ok ( my $remote = Etsy::StatsD->new('localhost', 123), 'created with host, port combo');
 is ( $remote->{sockets}[0]->peerport, 123, 'used specified port');
 
 my $mock_server;
 ok( $mock_server = Test::TCP->new(
         listen => 1,
         code   => sub {  },
-    )
+    ),
+    "mock server setup"
 );
-ok ( my $spray = Etsy::StatsD->new(['localhost','localhost:8126',sprintf('localhost:%d:tcp', $mock_server->port)], 8125) );
+ok ( my $spray = Etsy::StatsD->new(['localhost','localhost:8126',sprintf('localhost:%d:tcp', $mock_server->port)], 8125), "multiple dispatch with tcp" );
 is ( $spray->{sockets}[0]->peerport, 8125, 'port works in array of hosts');
 is ( $spray->{sockets}[1]->peerport, 8126, 'custom port works in array of hosts');
 is ( $spray->{sockets}[2]->protocol, 6, 'TCP protocol  works in array of hosts');
+
+my $err;
+eval {
+    my $t = Etsy::StatsD->new(['localhost', 'localhost:8126:igmp']);
+} or do { $err = $@; };
+ok( defined $err && $err =~ /Invalid protocol/, "invalid protocol dies" ) or diag($err);

--- a/t/Etsy-StatsD.t
+++ b/t/Etsy-StatsD.t
@@ -1,5 +1,5 @@
 use strict;
-use Test::More tests=>23;
+use Test::More tests=>24;
 use Test::MockModule;
 use Test::TCP;
 use Etsy::StatsD;
@@ -62,6 +62,12 @@ is ( $spray->{sockets}[2]->protocol, 6, 'TCP protocol  works in array of hosts')
 
 my $err;
 eval {
-    my $t = Etsy::StatsD->new(['localhost', 'localhost:8126:igmp']);
+    my $t = Etsy::StatsD->new('localhost:8126:igmp');
 } or do { $err = $@; };
 ok( defined $err && $err =~ /Invalid protocol/, "invalid protocol dies" ) or diag($err);
+
+eval {
+    my $t = Etsy::StatsD->new(['localhost', 'localhost:8126:igmp']);
+} or do { $err = $@; };
+ok( defined $err && $err =~ /Invalid protocol/, "invalid protocol dies in array ref" ) or diag($err);
+


### PR DESCRIPTION
In order to provide for long downtimes for statsd endpoints, or to aggregate
statsd metrics at multiple levels, it is necessary to send data to
multiple endpoints.  This is accomplished while maintaining backwards
compatbility.

```
my $statsd = Etsy::StatsD->new();
my $statsd = Etsy::StatsD->new( 'statagg1' );
my $statsd = Etsy::StatsD->new( 'statagg1', 8130 );
```

Continue to work.  New behavior is added:

```
my $statsd = Etsy::StatsD->new(['localhost', 'statagg1']);
# Sends all metrics (with the same results from sampling) to
# localhost:8125 and the statagg1:8125.

my $statsd = Etsy::StatsD->new(['localhost:8125', 'statagg1', 'statagg2' ]);
# To: localhost:8125, statagg1:8130, statagg2:8130
```

There are two "real world" use cases:

```
Host local statsd instance to aggregate in a host metrics namespace:
    statsd.hosts.<hostsname>.counters ..

Datacenter specific aggregator:
    statsd.dc.<datacenter>.counters ..

Global aggregator:
    statsd.global.counters ..
```

Because the replication is being done at this level, not by wrapping the
Etsy::StatsD objects, the sampled data is consistent across the
views.  It's still UDP, so there will be loss, but we need to start with
a level playing field to ensure all levels of aggregation are playing
with the same data sets.

Another use is for HA on statsd.  Reboots for kernel upgrades are common
practice and having the ability to down an aggregator is key.  You can
now specify multiple hosts and those aggregators will be sent the same
data. Since graphite operates on a "last metric for bucket wins", we can
send duplicate data without corrupting the system, ie:

```
Client -> StatsD Aggregater ---> Graphite
     `--> StatsD Aggregater _/
```

There's some hand waving around which statsd instance will be the last
and misalignment with the "buckets" but this is as close to the sun we
can fly without getting burnt with high levels of complexity.
